### PR TITLE
feat: block mode configuration

### DIFF
--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -1,12 +1,20 @@
 import { bootstrap, MoniconConfig } from "@monicon/core";
 import type { Plugin } from "esbuild";
 
+const pluginName = "esbuild-monicon";
+
 export const monicon = (options?: MoniconConfig): Plugin => {
+  let bootstrapPromise: Promise<void> | null = null;
+
   return {
-    name: "esbuild-monicon",
+    name: pluginName,
     setup(build) {
-      build.onStart(async () => {
-        await bootstrap(options);
+      build.onStart(() => {
+        if (!bootstrapPromise) {
+          bootstrapPromise = bootstrap(options);
+        }
+
+        return bootstrapPromise;
       });
     },
   };

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,7 +1,6 @@
 import type { PluginOption } from "vite";
 import { bootstrap, MoniconConfig } from "@monicon/core";
 
-// Remix's vite plugin calls resolveId before buildStart, so we need to wait for the bootstrap to complete before resolving the id.
 let bootstrapPromise: Promise<void> | null = null;
 
 export const monicon = (config?: MoniconConfig): PluginOption => {
@@ -15,11 +14,8 @@ export const monicon = (config?: MoniconConfig): PluginOption => {
         process.env.NODE_ENV === "development";
 
       bootstrapPromise = bootstrap({ watch: isWatching, ...config });
-    },
-    resolveId: async () => {
-      await bootstrapPromise;
 
-      return;
+      await bootstrapPromise;
     },
     config: async () => {
       return {


### PR DESCRIPTION
### Dev / Build blocking capability comparison

| Tool | Can block in **Dev** (before server starts) | Can block in **Build** | Notes |
|------|--------------------------------------------|------------------------|-------|
| **Vite** | ✅ Yes | ✅ Yes | `configureServer` (dev), `buildStart` (build) support async blocking |
| **Webpack** | ✅ Yes | ✅ Yes | `beforeRun` / `watchRun` truly block execution |
| **Rollup** | ❌ No server | ✅ Yes | No dev server; `buildStart` fully blocks |
| **esbuild** | ❌ No | ✅ Yes | `onStart` blocks `build()`, **cannot block** `context().serve()` |
| **Rspack** | ✅ Yes | ✅ Yes | Webpack-compatible hooks; blocking supported |
| **Nuxt** | ✅ Yes | ✅ Yes | Hooks (`build:before`, `nitro:build:before`) await Promises |
| **Metro (React Native)** | ❌ No | ❌ No | No true pre-start blocking hook; server starts immediately |